### PR TITLE
5AM unsuccessful

### DIFF
--- a/keycloak/docker-compose.yml
+++ b/keycloak/docker-compose.yml
@@ -1,6 +1,3 @@
-# docker-compose.yml - The Final Version
-version: "3.8"
-
 services:
   nginx:
     image: nginx:1.28.0-alpine
@@ -11,7 +8,6 @@ services:
       - ./nginx.conf:/etc/nginx/conf.d/default.conf
     depends_on:
       - oauth2
-      - keycloak
     restart: unless-stopped
     networks:
       - general-network
@@ -24,13 +20,14 @@ services:
       - -c 
       - |
         echo 'Waiting for Keycloak to start...'
-        sleep 40;
+        sleep 45;
         echo 'Starting oauth2-proxy...';
-        oauth2-proxy
+        oauth2-proxy 
     environment:
-      OAUTH2_PROXY_OIDC_ISSUER_URL: "http://keycloak:8080/realms/devops-mission"
-      OAUTH2_PROXY_REDIRECT_URL: "http://localhost/oauth2/callback"
-      OAUTH2_PROXY_UPSTREAMS: "http://nocodb:8080"
+      OAUTH2_PROXY_COOKIE_SECURE: "false" # localhost, DUUUH
+      OAUTH2_PROXY_OIDC_ISSUER_URL: "http://localhost/realms/devops-mission"
+      OAUTH2_PROXY_REDIRECT_URL: "http://localhost/oauth2/callback" # Also ensure this is set correctly
+      # OAUTH2_PROXY_UPSTREAMS: "http://nocodb:8080"
       OAUTH2_PROXY_PROVIDER: "oidc"
       OAUTH2_PROXY_CLIENT_ID: "nocodb"
       OAUTH2_PROXY_CLIENT_SECRET: "meI8zNQlO1UuejjmINpJrFtrmLmL6LMR"
@@ -38,6 +35,11 @@ services:
       OAUTH2_PROXY_EMAIL_DOMAINS: "*"
       OAUTH2_PROXY_HTTP_ADDRESS: "0.0.0.0:4180"
       OAUTH2_PROXY_SKIP_PROVIDER_BUTTON: "true"
+    extra_hosts:
+      - "localhost:host-gateway"
+    depends_on:
+      - keycloak
+    restart: unless-stopped
     networks:
       - general-network
 
@@ -45,7 +47,7 @@ services:
     image: quay.io/keycloak/keycloak:latest
     container_name: keycloak
     environment:
-      KC_HOSTNAME: keycloak
+      KC_HOSTNAME: localhost
       KC_HOSTNAME_URL: http://localhost
       KC_PROXY: "edge"
       KC_HTTP_ENABLED: "true"
@@ -56,9 +58,12 @@ services:
       KEYCLOAK_ADMIN: ${KC_ADMIN_TAG}
       KEYCLOAK_ADMIN_PASSWORD: ${KC_ADMIN_PASSWORD_TAG}
     command: start
+    ports:
+      - "8080:8080"
     depends_on:
       postgres:
         condition: service_healthy
+    restart: unless-stopped
     networks:
       - general-network
 
@@ -69,8 +74,13 @@ services:
       postgres:
         condition: service_healthy
     environment:
+      NC_AUTH_TYPE: proxy
+      NC_AUTH_PROXY_HEADER: "X-Forwarded-Email"
       NC_DB: "pg://postgres:5432?u=${PG_USER_TAG:-postgres}&p=${PG_PASSWORD_TAG:-password}&d=${PG_DB_TAG:-root_db}"
       NC_DISABLE_AUDIT: true
+      NC_PUBLIC_URL: "http://localhost"
+      NC_ADMIN_EMAIL: "changeme"
+      NC_ADMIN_PASSWORD: "changeme"
     restart: unless-stopped
     volumes:
       - ./nocodb_data:/usr/app/data
@@ -89,6 +99,7 @@ services:
     healthcheck:
       test: ["CMD","pg_isready","-U","keycloak"]
       interval: 10s
+    restart: unless-stopped
     networks:
       - general-network
 

--- a/keycloak/nginx.conf
+++ b/keycloak/nginx.conf
@@ -1,32 +1,61 @@
-# The final, working nginx.conf
 server {
     listen 80;
     server_name localhost;
 
-    # These two lines are the fix. They increase the buffer
-    # sizes to handle the long authentication URLs.
-    proxy_buffer_size   128k;
-    proxy_buffers   4 256k;
-    proxy_busy_buffers_size   256k;
-
+    # This location handles the main entry point and all other requests.
+    # It will trigger the authentication check.
     location / {
-        proxy_pass http://oauth2:4180;
+        auth_request /oauth2/auth;
+        error_page 401 = /oauth2/sign_in;
+
+        auth_request_set $user $upstream_http_x_forwarded_user;
+        auth_request_set $email $upstream_http_x_forwarded_email;
+        proxy_set_header X-User $user;
+        proxy_set_header X-Forwarded-Email $email; # Use the correct header for NocoDB
+
+        proxy_pass http://nocodb:8080;
         proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Scheme $scheme;
-        proxy_set_header X-Auth-Request-Redirect $request_uri;
     }
 
-    # The Keycloak login page itself
-    location /realms/ {
-        proxy_pass http://keycloak:8080;
+    # This block handles all requests for NocoDB's assets.
+    # By placing it here, we ensure that these requests are also authenticated.
+    location /dashboard/ {
+        auth_request /oauth2/auth;
+        error_page 401 = /oauth2/sign_in;
+
+        auth_request_set $user $upstream_http_x_forwarded_user;
+        auth_request_set $email $upstream_http_x_forwarded_email;
+        proxy_set_header X-User $user;
+        proxy_set_header X-Forwarded-Email $email;
+
+        proxy_pass http://nocodb:8080;
         proxy_set_header Host $host;
     }
 
-    # The callback URL after logging in
+    # The authentication endpoints
     location /oauth2/ {
         proxy_pass http://oauth2:4180;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Scheme $scheme;
+    }
+
+    location = /oauth2/auth {
+        proxy_pass http://oauth2:4180;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header Content-Length "";
+        proxy_pass_request_body off;
+    }
+
+    # Keycloak's own UI assets and API
+    location /resources/ {
+        proxy_pass http://keycloak:8080;
+        proxy_set_header Host $host;
+    }
+
+    location /realms/ {
+        proxy_pass http://keycloak:8080;
+        proxy_set_header Host $host;
     }
 }


### PR DESCRIPTION
I guess that's it. I done everything I could, logs look clean, trusted headers are passed correctly. You can test yourself and prove me wrong, I'll be happy to see the *real* right solution. Creds here don't make sense, forget about it. NocoDB just doesn't support trusted proxy sign in as [this feature is paid](https://nocodb.com/docs/product-docs/account-settings/authentication/overview).